### PR TITLE
removed storage offer from deploy command

### DIFF
--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -6,7 +6,7 @@ import { ConfigLoader } from '../../common/loader.config';
 
 import { teeProviderDeployer } from './tee-provider-deployer';
 import { resourceProviderDeployer } from './resource-provider-deployer';
-import { MINUTES_IN_WEEK, PROVIDER_PROVISIONER_OFFER, STORAGE_OFFER } from '../../common/constant';
+import { MINUTES_IN_WEEK, PROVIDER_PROVISIONER_OFFER } from '../../common/constant';
 
 export type DeployTeeCommandOptions = ConfigCommandParam & {
   config: string;
@@ -18,7 +18,6 @@ export type DeployResourceCommandOptions = ConfigCommandParam & {
   teeOffer: string;
   solutionOffer: string;
   baseImageOffer: string;
-  storageOffer: string;
   minRentMinutes: string;
 };
 
@@ -58,7 +57,6 @@ const deployResourceProviderCommandWrapper = (command: Command): void => {
       '--base-image-offer <id,slot>',
       'Base image offer (optional). If slot is not specified, it will be autoselected',
     )
-    .option('--storage-offer <id,slot>', 'Storage offer', STORAGE_OFFER)
     .option(
       '--min-rent-minutes <number>',
       'Provider hosting time to be paid in advance. If not specified, the first week will be prepaid',

--- a/src/commands/deploy/resource-provider-deployer.ts
+++ b/src/commands/deploy/resource-provider-deployer.ts
@@ -69,7 +69,6 @@ export async function resourceProviderDeployer(params: {
       tag: `${authorityAddress}/${now}`,
     };
 
-
     const uploadResult = await spctlService.uploadToStorJ(uploadParams);
 
     logger.info(

--- a/src/commands/deploy/resource-provider-deployer.ts
+++ b/src/commands/deploy/resource-provider-deployer.ts
@@ -26,7 +26,6 @@ export async function resourceProviderDeployer(params: {
     teeOffer,
     solutionOffer,
     baseImageOffer,
-    storageOffer,
     minRentMinutes,
   } = params.options;
 
@@ -70,14 +69,6 @@ export async function resourceProviderDeployer(params: {
       tag: `${authorityAddress}/${now}`,
     };
 
-    if (answers.acquireStorJCredentials?.hasOwn === false) {
-      if (storageOffer.split(',').length === 1) {
-        throw new Error(`Storage slot must be specified for offer ${storageOffer}`);
-      } else {
-        uploadParams.storage = storageOffer;
-      }
-      uploadParams.minRentMinutes = minRentMinutes;
-    }
 
     const uploadResult = await spctlService.uploadToStorJ(uploadParams);
 
@@ -92,7 +83,6 @@ export async function resourceProviderDeployer(params: {
       teeId: pickedTeeOffer,
       solutionOffer: solutionOffer,
       baseImageOffer: baseImageOffer,
-      storageOffer: storageOffer,
       minRentMinutes,
     });
 

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -65,5 +65,4 @@ export const DEFAULT_RETRY_COUNT = 5;
 export const TEE_OFFERS: string[] = JSON.parse(process.env.TEE_OFFERS || '["1"]');
 export const PROVIDER_PROVISIONER_OFFER = process.env.PROVIDER_PROVISIONER_OFFER;
 export const BASE_IMAGE_OFFER = process.env.BASE_IMAGE_OFFER;
-export const STORAGE_OFFER = process.env.STORAGE_OFFER;
 export const MINUTES_IN_WEEK = 10080;

--- a/src/services/spctl/service.ts
+++ b/src/services/spctl/service.ts
@@ -27,8 +27,6 @@ export type UploadToStorJParams = {
   filePath: string;
   resultPath: string;
   tag: string;
-  storage?: string;
-  minRentMinutes?: string;
 };
 
 export class SpctlService implements ISpctlService {
@@ -254,13 +252,6 @@ export class SpctlService implements ISpctlService {
       params.resultPath,
     ];
 
-    if (params.storage) {
-      args.push('--storage', params.storage);
-      if (params.minRentMinutes) {
-        args.push('--min-rent-minutes', params.minRentMinutes);
-      }
-    }
-
     const response = await this.exec(args);
 
     const uploadSuccessRegexp = new RegExp(/File\swas\suploaded\ssuccessfully/gm);
@@ -278,7 +269,6 @@ export class SpctlService implements ISpctlService {
     teeId: string;
     solutionOffer: string;
     baseImageOffer: string;
-    storageOffer: string;
     dataResourceFilePath: string;
     minRentMinutes: string;
   }): Promise<string> {
@@ -289,8 +279,6 @@ export class SpctlService implements ISpctlService {
       params.teeId,
       '--solution',
       params.solutionOffer,
-      '--storage',
-      params.storageOffer,
       '--data',
       params.dataResourceFilePath,
       '--min-rent-minutes',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed storage-offer support from resource deployment; CLI no longer accepts a storage-offer flag or default.
  - StorJ uploads no longer accept storage or min-rent-minutes options.
  - Workflow creation no longer includes a storage offer parameter.
  - Deployment behavior otherwise unchanged.

- Chores
  - Removed related unused configuration constants and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->